### PR TITLE
Removing comments about Security guide being incorrect

### DIFF
--- a/controls/check-block.rb
+++ b/controls/check-block.rb
@@ -69,7 +69,6 @@ control 'check-block-04' do
   ref 'http://docs.openstack.org/security-guide/block-storage/checklist.html#check-block-04-is-tls-enabled-for-authentication'
 
   describe ini(cinder_conf_file) do
-    # We test the value of auth_uri, rather than auth_protocol or identity_uri as the doc in ref is currently out of date
     its(['keystone_authtoken','auth_uri']) { should match /^https:/ }
 
     # nil is acceptable as false is the default value

--- a/controls/check-compute.rb
+++ b/controls/check-compute.rb
@@ -66,7 +66,6 @@ control 'check-compute-04' do
   ref 'http://docs.openstack.org/security-guide/compute/checklist.html#check-compute-04-is-secure-protocol-used-for-authentication'
 
   describe ini(nova_conf_file) do
-    # We test the value of auth_uri, rather than auth_protocol or identity_uri as the doc in ref is currently out of date
     its(['keystone_authtoken','auth_uri']) { should match /^https:/ }
 
     # nil is acceptable as false is the default value

--- a/controls/check-neutron.rb
+++ b/controls/check-neutron.rb
@@ -72,7 +72,6 @@ control 'check-neutron-04' do
   ref 'http://docs.openstack.org/security-guide/networking/checklist.html#check-neutron-04-is-secure-protocol-used-for-authentication'
 
   describe ini(neutron_conf_file) do
-    # We test the value of auth_uri, rather than auth_protocol or identity_uri as the doc in ref is currently out of date
     its(['keystone_authtoken','auth_uri']) { should match /^https:/ }
 
     # nil is acceptable as false is the default value


### PR DESCRIPTION
I submitted patches upstream to the guide which have been merged
so the guide and checks implemented in the controls now match.

https://review.openstack.org/#/q/project:openstack/security-doc+status:merged+owner:%22Travis+Truman+(automagically)+%253Ctravis_truman%2540cable.comcast.com%253E%22