### PR TITLE
Implement Glance controls based on Cinder guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The control checklists for Keystone, Horizon, Cinder, Nova and Neutron are imple
 
 Some control implementation exists for Swift and Manila, but has not been tested.
 
+Beta-level controls exist for Glance. These controls are inspired by those currently recommended in the OpenStack Security Guide for Cinder.
+
 ## Installation
 
 ```shell
@@ -81,6 +83,14 @@ bundle exec inspec exec . \
   --controls check-neutron-01 check-neutron-02 \
     check-neutron-03 check-neutron-04 \
     check-neutron-05
+```
+
+### Image controls
+
+```shell
+bundle exec inspec exec . \
+  --controls check-image-01 check-image-02 \
+    check-image-03 check-image-04
 ```
 
 # To Do

--- a/controls/check-image.rb
+++ b/controls/check-image.rb
@@ -1,0 +1,74 @@
+# All checks here are not (yet) in the OpenStack Security Guide
+# They are inspired by those at http://docs.openstack.org/security-guide/block-storage/checklist.html
+
+glance_conf_dir = '/etc/glance'
+
+config_files = %w(
+  glance-api-paste.ini
+  glance-api.conf
+  glance-cache.conf
+  glance-manage.conf
+  glance-registry-paste.ini
+  glance-registry.conf
+  glance-scrubber.conf
+  glance-swift-store.conf
+  policy.json
+  schema-image.json
+  schema.json
+)
+
+control 'check-image-01' do
+
+  title 'Glance config files should be owned by root user and glance group.'
+
+  config_files.each do |glance_conf_file|
+    describe file("#{glance_conf_dir}/#{glance_conf_file}") do
+      it { should be_owned_by 'root' }
+      its('group') { should eq 'glance' }
+    end
+  end
+end
+
+control 'check-image-02' do
+
+  title 'Strict permissions should be set for all Glance config files.'
+
+  config_files.each do |glance_conf_file|
+    describe file("#{glance_conf_dir}/#{glance_conf_file}") do
+      its('mode') { should cmp '0640' }
+    end
+  end
+end
+
+control 'check-image-03' do
+
+  title 'Glance should use Keystone for authentication.'
+
+  # nil is acceptable as keystone is default value
+  describe ini("#{glance_conf_dir}/glance-api.conf") do
+    its(['DEFAULT','auth_strategy']) { should be_nil.or eq "keystone" }
+  end
+
+  describe ini("#{glance_conf_dir}/glance-registry.conf") do
+    its(['DEFAULT','auth_strategy']) { should be_nil.or eq "keystone" }
+  end
+end
+
+control 'check-image-04' do
+
+  title 'Glance should communicate with Keystone using TLS.'
+
+  describe ini("#{glance_conf_dir}/glance-api.conf") do
+    its(['keystone_authtoken','auth_uri']) { should match /^https:/ }
+
+    # nil is acceptable as false is the default value
+    its(['keystone_authtoken','insecure']) { should be_nil.or eq "False" }
+  end
+
+  describe ini("#{glance_conf_dir}/glance-registry.conf") do
+    its(['keystone_authtoken','auth_uri']) { should match /^https:/ }
+
+    # nil is acceptable as false is the default value
+    its(['keystone_authtoken','insecure']) { should be_nil.or eq "False" }
+  end
+end


### PR DESCRIPTION
The OpenStack Security guide does not currently include
a checklist of controls for Glance, but many of the checklist
items for Cinder apply to Glance.