### PR TITLE
Implement Heat controls based on Cinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ bundle exec inspec exec . \
     check-image-03 check-image-04
 ```
 
+### Orchestration controls
+```shell
+bundle exec inspec exec . \
+  --controls check-orchestration-01 check-orchestration-02 \
+    check-orchestration-03 --attrs attributes.yml
+```
+
+attributes.yml has the following contents
+```yaml
+heat_enabled: true
+```
+
 # To Do
 
 https://github.com/chef-partners/inspec-openstack-security/issues

--- a/controls/check-orchestration.rb
+++ b/controls/check-orchestration.rb
@@ -1,0 +1,52 @@
+# All checks here are not (yet) in the OpenStack Security Guide
+# They are inspired by those at http://docs.openstack.org/security-guide/block-storage/checklist.html
+
+heat_conf_dir = '/etc/heat'
+
+default_config_files = %w(
+  api-paste.ini
+  heat.conf
+  policy.json
+  heat_api_audit_map.conf
+)
+
+config_files = attribute('heat_config_files', default: default_config_files, description: 'OpenStack Heat configuration files')
+heat_enabled = attribute('heat_enabled', default: false, description: 'OpenStack Inspec checks for Heat should be enabled')
+
+control 'check-orchestration-01' do
+
+  title 'Heat config files should be owned by root user and heat group.'
+  only_if { heat_enabled }
+
+  config_files.each do |heat_conf_file|
+    describe file("#{heat_conf_dir}/#{heat_conf_file}") do
+      it { should be_owned_by 'root' }
+      its('group') { should eq 'heat' }
+    end
+  end
+end
+
+control 'check-orchestration-02' do
+
+  title 'Strict permissions should be set for all Heat config files.'
+  only_if { heat_enabled }
+
+  config_files.each do |heat_conf_file|
+    describe file("#{heat_conf_dir}/#{heat_conf_file}") do
+      its('mode') { should cmp '0640' }
+    end
+  end
+end
+
+control 'check-orchestration-03' do
+
+  title 'Heat should communicate with Keystone using TLS.'
+  only_if { heat_enabled }
+
+  describe ini("#{heat_conf_dir}/heat.conf") do
+    its(['keystone_authtoken','auth_uri']) { should match /^https:/ }
+
+    # nil is acceptable as false is the default value
+    its(['keystone_authtoken','insecure']) { should be_nil.or eq "False" }
+  end
+end


### PR DESCRIPTION
The OpenStack Security guide does not currently include
a checklist of controls for Heat, so the controls were added
based on what glance and cinder do. Since heat is usually optional,
the controls will not run unless heat_enabled is specified to
be true by attributes.