### PR TITLE
Implement Ceilometer and AODH controls based on Cinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ attributes.yml has the following contents
 heat_enabled: true
 ```
 
+### Telemetry and Telemetry Alarming controls
+
+```shell
+inspec exec . --controls check-telemetry-01 check-telemetry-02 \
+                check-telemetry-03 check-telemetry-04 \
+                check-telemetry-alarming-01 check-telemetry-alarming-02 \
+                check-telemetry-alarming-03 \
+                --attrs attributes.yml
+```
+
+attributes.yml has the following contents
+```yaml
+ceilometer_enabled: true
+aodh_enabled: true
+```
+
 # To Do
 
 https://github.com/chef-partners/inspec-openstack-security/issues

--- a/controls/check-telemetry-alarming.rb
+++ b/controls/check-telemetry-alarming.rb
@@ -1,0 +1,56 @@
+# All checks here are not (yet) in the OpenStack Security Guide
+# They are inspired by those at http://docs.openstack.org/security-guide/block-storage/checklist.html
+
+conf_dir = '/etc/aodh'
+
+default_config_files = %w(
+  aodh.conf
+  api_paste.ini
+  policy.json
+)
+
+config_files = attribute(
+    'aodh_config_files', default: default_config_files,
+    description: 'OpenStack AODH configuration files')
+
+aodh_enabled = attribute(
+    'aodh_enabled', default: false,
+    description: 'OpenStack Inspec checks for AODH should be enabled')
+
+control 'check-telemetry-alarming-01' do
+
+  title 'AODH config files should be owned by root user and aodh group.'
+  only_if { aodh_enabled }
+
+  config_files.each do |conf_file|
+    describe file("#{conf_dir}/#{conf_file}") do
+      it { should be_owned_by 'root' }
+      its('group') { should eq 'aodh' }
+    end
+  end
+end
+
+control 'check-telemetry-alarming-02' do
+
+  title 'Strict permissions should be set for all AODH config files.'
+  only_if { aodh_enabled}
+
+  config_files.each do |conf_file|
+    describe file("#{conf_dir}/#{conf_file}") do
+      its('mode') { should cmp '0640' }
+    end
+  end
+end
+
+control 'check-telemetry-alarming-03' do
+
+  title 'AODH should communicate with Keystone using TLS.'
+  only_if { aodh_enabled }
+
+  describe ini("#{conf_dir}/aodh.conf") do
+    its(['keystone_authtoken','auth_uri']) { should match /^https:/ }
+
+    # nil is acceptable as false is the default value
+    its(['keystone_authtoken','insecure']) { should be_nil.or eq "False" }
+  end
+end

--- a/controls/check-telemetry.rb
+++ b/controls/check-telemetry.rb
@@ -1,0 +1,70 @@
+# All checks here are not (yet) in the OpenStack Security Guide
+# They are inspired by those at http://docs.openstack.org/security-guide/block-storage/checklist.html
+
+conf_dir = '/etc/ceilometer'
+
+default_config_files = %w(
+  api_paste.ini
+  event_pipeline.yaml
+  policy.json
+  ceilometer.conf
+  event_definitions.yaml
+  pipeline.yaml
+)
+
+config_files = attribute(
+    'ceilometer_config_files', default: default_config_files,
+    description: 'OpenStack Ceilometer configuration files')
+
+ceilometer_enabled = attribute(
+    'ceilometer_enabled', default: false,
+    description: 'OpenStack Inspec checks for Ceilometer should be enabled')
+
+control 'check-telemetry-01' do
+
+  title 'Ceilometer config files should be owned by root user and ceilometer group.'
+  only_if { ceilometer_enabled }
+
+  config_files.each do |conf_file|
+    describe file("#{conf_dir}/#{conf_file}") do
+      it { should be_owned_by 'root' }
+      its('group') { should eq 'ceilometer' }
+    end
+  end
+end
+
+control 'check-telemetry-02' do
+
+  title 'Strict permissions should be set for all Ceilometer config files.'
+  only_if { ceilometer_enabled }
+
+  config_files.each do |conf_file|
+    describe file("#{conf_dir}/#{conf_file}") do
+      its('mode') { should cmp '0640' }
+    end
+  end
+end
+
+control 'check-telemetry-03' do
+
+  title 'Ceilometer should use Keystone for authentication.'
+  only_if { ceilometer_enabled }
+
+  # nil is acceptable as keystone is default value
+  describe ini("#{conf_dir}/ceilometer.conf") do
+    its(['DEFAULT','auth_strategy']) { should be_nil.or eq "keystone" }
+  end
+end
+
+control 'check-telemetry-04' do
+
+  title 'Ceilometer should communicate with Keystone using TLS.'
+  only_if { ceilometer_enabled }
+
+  describe ini("#{conf_dir}/ceilometer.conf") do
+    its(['keystone_authtoken','auth_uri']) { should match /^https:/ }
+
+    # nil is acceptable as false is the default value
+    its(['keystone_authtoken','insecure']) { should be_nil.or eq "False" }
+  end
+end


### PR DESCRIPTION
The OpenStack Security guide does not currently include
a checklist of controls for Ceilometer and AODH, so the controls were added
based on what glance and cinder do. Since Ceilometer or AODH
is usually optional, the controls will not run unless
ceilometer_enabled or aodh_enabled is specified to
be true by attributes.