### PR TITLE
use input instead of attribute

### DIFF
--- a/controls/check_dashboard.rb
+++ b/controls/check_dashboard.rb
@@ -3,19 +3,19 @@
 
 # All checks from http://docs.openstack.org/security-guide/dashboard/checklist.html
 
-horizon_config_dir = attribute(
+horizon_config_dir = input(
   'horizon_config_dir',
   default: '/etc/openstack-dashboard',
   description: 'OpenStack Dashboard config file path'
 )
 
-horizon_config_owner = attribute(
+horizon_config_owner = input(
   'horizon_config_owner',
   default: 'root',
   description: 'OpenStack Dashboard config file owner'
 )
 
-horizon_config_group = attribute(
+horizon_config_group = input(
   'horizon_config_group',
   default: 'horizon',
   description: 'OpenStack Dashboard config file group'

--- a/inspec.yml
+++ b/inspec.yml
@@ -6,6 +6,7 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Verifies the guidelines of OpenStack Security Guide
+inspec_version: '>= 4.6.3'
 version: 1.0.3
 supports:
     - os-family: linux


### PR DESCRIPTION
In the last versions of Inspec and cinc-auditor, attribute is deprecated and input should be used.

https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper/